### PR TITLE
Update requirements to fix dependabot alerts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -88,7 +88,7 @@ PyYAML==6.0.2
 pyzmq==26.4.0
 readme_renderer==44.0
 referencing==0.36.2
-requests==2.32.3
+requests==2.32.4
 requests-toolbelt==1.0.0
 rfc3986==2.0.0
 rich==14.0.0
@@ -105,7 +105,7 @@ traitlets==5.14.3
 twine==6.1.0
 typing-inspection==0.4.1
 typing_extensions==4.12.2
-urllib3==2.3.0
+urllib3==2.5.0
 virtualenv==20.30.0
 wcwidth==0.2.13
 webencodings==0.5.1


### PR DESCRIPTION
Fix the following security alerts:
![Screenshot from 2025-06-19 15-05-11](https://github.com/user-attachments/assets/39c5c73e-5b9c-427b-8df8-067fc0d126d0)
