### PR TITLE
Add flavour_id as input parameter for i2edge adapter

### DIFF
--- a/src/sunrise6g_opensdk/common/adapters_factory.py
+++ b/src/sunrise6g_opensdk/common/adapters_factory.py
@@ -29,9 +29,13 @@ from sunrise6g_opensdk.network.adapters.open5gs.client import (
 
 
 def _edgecloud_adapters_factory(client_name: str, base_url: str, **kwargs):
+    if client_name == "i2edge":
+        if "flavour_id" not in kwargs:
+            raise ValueError("Missing required 'flavour_id' for i2edge client.")
+
     edge_cloud_factory = {
         "aeros": lambda url, **kw: AerosClient(base_url=url, **kw),
-        "i2edge": lambda url: I2EdgeClient(base_url=url),
+        "i2edge": lambda url, **kw: I2EdgeClient(base_url=url, **kw),
         # "kubernetes": lambda url: kubernetesClient(base_url=url), Uncomment when import issues are solved
     }
     try:

--- a/src/sunrise6g_opensdk/edgecloud/adapters/i2edge/client.py
+++ b/src/sunrise6g_opensdk/edgecloud/adapters/i2edge/client.py
@@ -33,8 +33,9 @@ class EdgeApplicationManager(EdgeCloudManagementInterface):
     i2Edge Client
     """
 
-    def __init__(self, base_url: str):
+    def __init__(self, base_url: str, flavour_id: str):
         self.base_url = base_url
+        self.flavour_id = flavour_id
 
     def get_edge_cloud_zones(
         self, region: Optional[str] = None, status: Optional[str] = None
@@ -156,15 +157,10 @@ class EdgeApplicationManager(EdgeCloudManagementInterface):
         except I2EdgeError as e:
             raise e
 
-    def _select_best_flavour_for_app(self, zone_id) -> str:
-        """
-        Selects the best flavour for the specified app requirements in a given zone.
-        """
-        # list_of_flavours = self.get_edge_cloud_zones_details(zone_id)
-        # <logic that select the best flavour>
-        # TODO - Harcoded
-        flavourId = "67f3a0b0e3184a85952e174d"
-        return flavourId
+    # def _select_best_flavour_for_app(self, zone_id) -> str:
+    #     # list_of_flavours = self.get_edge_cloud_zones_details(zone_id)
+    #     # <logic that select the best flavour>
+    #     return flavourId
 
     def deploy_app(self, app_id: str, app_zones: List[Dict]) -> Dict:
         appId = app_id
@@ -172,15 +168,15 @@ class EdgeApplicationManager(EdgeCloudManagementInterface):
         profile_data = app["profile_data"]
         appProviderId = profile_data["appProviderId"]
         appVersion = profile_data["appMetaData"]["version"]
-        # TODO: Iterate in the list; deploy the app in all zones
         zone_info = app_zones[0]["EdgeCloudZone"]
         zone_id = zone_info["edgeCloudZoneId"]
-        flavourId = self._select_best_flavour_for_app(zone_id=zone_id)
+        # TODO: atm the flavour id is specified as an input parameter
+        # flavourId = self._select_best_flavour_for_app(zone_id=zone_id)
         app_deploy_data = schemas.AppDeployData(
             appId=appId,
             appProviderId=appProviderId,
             appVersion=appVersion,
-            zoneInfo=schemas.ZoneInfo(flavourId=flavourId, zoneId=zone_id),
+            zoneInfo=schemas.ZoneInfo(flavourId=self.flavour_id, zoneId=zone_id),
         )
         url = "{}/app/".format(self.base_url)
         payload = schemas.AppDeploy(app_deploy_data=app_deploy_data)

--- a/tests/common/test_invoke_edgecloud_clients.py
+++ b/tests/common/test_invoke_edgecloud_clients.py
@@ -8,6 +8,8 @@ EDGE_CLOUD_TEST_CASES = [
         "edgecloud": {
             "client_name": "i2edge",
             "base_url": "http://test-nbi-i2edge.sunrise6g",
+            # Additional parameters for i2Edge client:
+            "flavour_id": "id",
         }
     },
     {

--- a/tests/edgecloud/test_cases.py
+++ b/tests/edgecloud/test_cases.py
@@ -4,6 +4,7 @@ test_cases = [
         "edgecloud": {
             "client_name": "i2edge",
             "base_url": "http://192.168.123.48:30769/",
+            "flavour_id": "67f3a0b0e3184a85952e174d",
         }
     },
     # {

--- a/tests/edgecloud/test_e2e.py
+++ b/tests/edgecloud/test_e2e.py
@@ -10,9 +10,9 @@
 #   - Sergio Giménez (sergio.gimenez@i2cat.net)
 ##
 """
-EdgeCloud Platform Integration Tests
+EdgeCloud adapters Integration Tests
 
-Validates the complete application lifecycle across multiple adapters:
+Validates the complete application lifecycle:
 1. Infrastructure (zone discovery)
 2. Artefact management (create/delete)
 3. Application lifecycle (onboard/deploy/undeploy/delete app onboarded)
@@ -22,7 +22,7 @@ Key features:
 - Tests configuration available in test_config.py
 - Ensures proper resource cleanup
 - Uses shared test constants and CAMARA-compliant manifests
-- Includes i2edge-specific tests where needed
+- Includes artefact unit tests where needed
 """
 import time
 


### PR DESCRIPTION
Now, for the Edge CLoud i2Edge adapter, the flavour_id can be defined as an input parameter when declaring the SDK:
```
adapter_specs = {
    "edgecloud": {
        "client_name": "i2edge",
        "base_url": "<>",
        "flavour_id": "<>"
    },
    "network": {
        "client_name": "open5gs",
        "base_url": "<>",
        "scs_as_id": "<>",
    }
}
```