### PR TITLE
Added error handling for none implemented methods from interface NetworkManagement

### DIFF
--- a/src/sunrise6g_opensdk/network/adapters/open5gcore/client.py
+++ b/src/sunrise6g_opensdk/network/adapters/open5gcore/client.py
@@ -40,10 +40,22 @@ class NetworkManager(BaseNetworkClient):
             )
 
     def add_core_specific_qod_parameters(
-        self,
-        session_info: schemas.CreateSession,
-        subscription: schemas.AsSessionWithQoSSubscription,
+            self,
+            session_info: schemas.CreateSession,
+            subscription: schemas.AsSessionWithQoSSubscription,
     ) -> None:
         flow_id = qos_support_map[session_info.qosProfile.root]
         subscription.flowInfo = build_flows(flow_id, session_info)
         subscription.ueIpv4Addr = "192.168.6.1"  # ToDo
+
+    def add_core_specific_ti_parameters(
+            self,
+            traffic_influence_info: schemas.CreateTrafficInfluence,
+            subscription: schemas.TrafficInfluSub,
+    ):
+        raise NotImplementedError("add_core_specific_ti_parameters not implemented for Open5GCore")
+
+    def core_specific_traffic_influence_validation(
+            self, traffic_influence_info: schemas.CreateTrafficInfluence
+    ) -> None:
+        raise NotImplementedError("core_specific_traffic_influence_validation not implemented for Open5GCore")

--- a/src/sunrise6g_opensdk/network/adapters/open5gcore/client.py
+++ b/src/sunrise6g_opensdk/network/adapters/open5gcore/client.py
@@ -40,22 +40,26 @@ class NetworkManager(BaseNetworkClient):
             )
 
     def add_core_specific_qod_parameters(
-            self,
-            session_info: schemas.CreateSession,
-            subscription: schemas.AsSessionWithQoSSubscription,
+        self,
+        session_info: schemas.CreateSession,
+        subscription: schemas.AsSessionWithQoSSubscription,
     ) -> None:
         flow_id = qos_support_map[session_info.qosProfile.root]
         subscription.flowInfo = build_flows(flow_id, session_info)
         subscription.ueIpv4Addr = "192.168.6.1"  # ToDo
 
     def add_core_specific_ti_parameters(
-            self,
-            traffic_influence_info: schemas.CreateTrafficInfluence,
-            subscription: schemas.TrafficInfluSub,
+        self,
+        traffic_influence_info: schemas.CreateTrafficInfluence,
+        subscription: schemas.TrafficInfluSub,
     ):
-        raise NotImplementedError("add_core_specific_ti_parameters not implemented for Open5GCore")
+        raise NotImplementedError(
+            "add_core_specific_ti_parameters not implemented for Open5GCore"
+        )
 
     def core_specific_traffic_influence_validation(
-            self, traffic_influence_info: schemas.CreateTrafficInfluence
+        self, traffic_influence_info: schemas.CreateTrafficInfluence
     ) -> None:
-        raise NotImplementedError("core_specific_traffic_influence_validation not implemented for Open5GCore")
+        raise NotImplementedError(
+            "core_specific_traffic_influence_validation not implemented for Open5GCore"
+        )


### PR DESCRIPTION
Following up on our email from 24th of June.

This resolves issue: Open5GCore: Declaration of non-supported methods #46