### PR TITLE
Docs/update readme edgecloud api

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Open source SDK to abstract CAMARA/GSMA Transformation Functions (TFs) for Edge 
 
 | API Name                  | Version |
 |---------------------------|---------|
-| Edge Application Management | [v0.9.3-wip](https://raw.githubusercontent.com/camaraproject/EdgeCloud/main/code/API_definitions/Edge-Application-Management.yaml) |
+| Edge Application Management | [v0.9.3-wip (Commit: 341025b)](https://raw.githubusercontent.com/camaraproject/EdgeCloud/main/code/API_definitions/Edge-Application-Management.yaml) |
 | Quality-on-Demand         | [v1.0.0](https://raw.githubusercontent.com/camaraproject/QualityOnDemand/refs/tags/r2.2/code/API_definitions/quality-on-demand.yaml) |
 | Location Retrieval        | [v0.4.0](https://raw.githubusercontent.com/camaraproject/DeviceLocation/refs/tags/r2.2/code/API_definitions/location-retrieval.yaml) |
 | Traffic Influence         | [v0.8.1](https://raw.githubusercontent.com/camaraproject/EdgeCloud/v0.8.1/code/API_definitions/Traffic_Influence.yaml) |

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Open source SDK to abstract CAMARA/GSMA Transformation Functions (TFs) for Edge 
 
 | API Name                  | Version |
 |---------------------------|---------|
-| Edge Application Management | [v0.9.3-wip (Commit: 341025b)](https://raw.githubusercontent.com/camaraproject/EdgeCloud/main/code/API_definitions/Edge-Application-Management.yaml) |
+| Edge Application Management | [v0.9.3-wip (Commit: e4f0e8b)](https://github.com/camaraproject/EdgeCloud/blob/e4f0e8b2e5c75eb2003b8b145c68352087b48e26/code/API_definitions/Edge-Application-Management.yaml) |
 | Quality-on-Demand         | [v1.0.0](https://raw.githubusercontent.com/camaraproject/QualityOnDemand/refs/tags/r2.2/code/API_definitions/quality-on-demand.yaml) |
 | Location Retrieval        | [v0.4.0](https://raw.githubusercontent.com/camaraproject/DeviceLocation/refs/tags/r2.2/code/API_definitions/location-retrieval.yaml) |
 | Traffic Influence         | [v0.8.1](https://raw.githubusercontent.com/camaraproject/EdgeCloud/v0.8.1/code/API_definitions/Traffic_Influence.yaml) |


### PR DESCRIPTION
Pull Request Overview
Updates the Edge Application Management API reference in the documentation to include a specific commit hash and link to the GitHub blob instead of the raw file URL.

- Changed the Edge Application Management API link from raw GitHub URL to a commit-specific GitHub blob URL
- Added commit hash reference (e4f0e8b) to the version identifier for better traceability